### PR TITLE
Parameters flag in build_loadable_extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,6 @@ cmake_minimum_required(VERSION 2.8.12)
 set(TARGET_NAME sqlite_scanner)
 project(${TARGET_NAME})
 include_directories(sqlite)
-build_loadable_extension(${TARGET_NAME} sqlite_scanner.cpp sqlite/sqlite3.c)
+
+set(PARAMETERS "-no-warnings")
+build_loadable_extension(${TARGET_NAME} ${PARAMETERS} sqlite_scanner.cpp sqlite/sqlite3.c)


### PR DESCRIPTION
This fixes an upcoming PR that introduces the parameters field to the `build_loadable_extension`. This field encoded as a string so as to be extensible in the future, and replaces the (previously borked) IGNORE_WARNINGS field (see duckdb/duckdb#4394).