### PR TITLE
Safe unique ptr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ ifeq (${OSX_BUILD_UNIVERSAL}, 1)
 endif
 BUILD_FLAGS=-DEXTENSION_STATIC_BUILD=1 -DBUILD_TPCH_EXTENSION=1 ${OSX_BUILD_UNIVERSAL_FLAG}
 
+DUCKDB_DIRECTORY=
+ifndef DUCKDB_DIR
+	DUCKDB_DIRECTORY=duckdb
+else
+	DUCKDB_DIRECTORY=${DUCKDB_DIR}
+endif
 
 pull:
 	git submodule init
@@ -36,7 +42,7 @@ test: release
 	./build/release/test/unittest --test-dir .
 
 format:
-	cp duckdb/.clang-format .
+	cp ${DUCKDB_DIRECTORY}/.clang-format .
 	find src -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
 	find . -iname CMakeLists.txt | xargs cmake-format -i
 	rm .clang-format

--- a/src/sqlite_db.cpp
+++ b/src/sqlite_db.cpp
@@ -163,7 +163,7 @@ void SQLiteDB::GetTableInfo(const string &table_name, ColumnList &columns, vecto
 		}
 		columns.AddColumn(std::move(column));
 		if (not_null) {
-			constraints.push_back(make_unique<NotNullConstraint>(LogicalIndex(cid)));
+			constraints.push_back(make_uniq<NotNullConstraint>(LogicalIndex(cid)));
 		}
 		if (pk) {
 			primary_key_index = cid;
@@ -176,9 +176,9 @@ void SQLiteDB::GetTableInfo(const string &table_name, ColumnList &columns, vecto
 	}
 	if (!primary_keys.empty()) {
 		if (primary_keys.size() == 1) {
-			constraints.push_back(make_unique<UniqueConstraint>(LogicalIndex(primary_key_index), true));
+			constraints.push_back(make_uniq<UniqueConstraint>(LogicalIndex(primary_key_index), true));
 		} else {
-			constraints.push_back(make_unique<UniqueConstraint>(std::move(primary_keys), true));
+			constraints.push_back(make_uniq<UniqueConstraint>(std::move(primary_keys), true));
 		}
 	}
 }

--- a/src/sqlite_extension.cpp
+++ b/src/sqlite_extension.cpp
@@ -31,7 +31,7 @@ DUCKDB_EXTENSION_API void sqlite_scanner_init(duckdb::DatabaseInstance &db) {
 	auto &config = DBConfig::GetConfig(db);
 	config.AddExtensionOption("sqlite_all_varchar", "Load all SQLite columns as VARCHAR columns", LogicalType::BOOLEAN);
 
-	config.storage_extensions["sqlite_scanner"] = make_unique<SQLiteStorageExtension>();
+	config.storage_extensions["sqlite_scanner"] = make_uniq<SQLiteStorageExtension>();
 
 	con.Commit();
 }
@@ -41,6 +41,6 @@ DUCKDB_EXTENSION_API const char *sqlite_scanner_version() {
 }
 
 DUCKDB_EXTENSION_API void sqlite_scanner_storage_init(DBConfig &config) {
-	config.storage_extensions["sqlite_scanner"] = make_unique<SQLiteStorageExtension>();
+	config.storage_extensions["sqlite_scanner"] = make_uniq<SQLiteStorageExtension>();
 }
 }

--- a/src/sqlite_scanner.cpp
+++ b/src/sqlite_scanner.cpp
@@ -44,7 +44,7 @@ struct SqliteGlobalState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> SqliteBind(ClientContext &context, TableFunctionBindInput &input,
                                            vector<LogicalType> &return_types, vector<string> &names) {
 
-	auto result = make_unique<SqliteBindData>();
+	auto result = make_uniq<SqliteBindData>();
 	result->file_name = input.inputs[0].GetValue<string>();
 	result->table_name = input.inputs[1].GetValue<string>();
 
@@ -114,7 +114,7 @@ static unique_ptr<NodeStatistics> SqliteCardinality(ClientContext &context, cons
 	D_ASSERT(bind_data_p);
 
 	auto bind_data = (const SqliteBindData *)bind_data_p;
-	return make_unique<NodeStatistics>(bind_data->max_rowid);
+	return make_uniq<NodeStatistics>(bind_data->max_rowid);
 }
 
 static idx_t SqliteMaxThreads(ClientContext &context, const FunctionData *bind_data_p) {
@@ -145,7 +145,7 @@ static unique_ptr<LocalTableFunctionState>
 SqliteInitLocalState(ExecutionContext &context, TableFunctionInitInput &input, GlobalTableFunctionState *global_state) {
 	auto bind_data = (const SqliteBindData *)input.bind_data;
 	auto &gstate = (SqliteGlobalState &)*global_state;
-	auto result = make_unique<SqliteLocalState>();
+	auto result = make_uniq<SqliteLocalState>();
 	result->column_ids = input.column_ids;
 	result->db = bind_data->global_db;
 	if (!SqliteParallelStateNext(context.client, input.bind_data, *result, gstate)) {
@@ -156,7 +156,7 @@ SqliteInitLocalState(ExecutionContext &context, TableFunctionInitInput &input, G
 
 static unique_ptr<GlobalTableFunctionState> SqliteInitGlobalState(ClientContext &context,
                                                                   TableFunctionInitInput &input) {
-	auto result = make_unique<SqliteGlobalState>(SqliteMaxThreads(context, input.bind_data));
+	auto result = make_uniq<SqliteGlobalState>(SqliteMaxThreads(context, input.bind_data));
 	result->position = 0;
 	return std::move(result);
 }
@@ -248,7 +248,7 @@ SqliteStatistics(ClientContext &context, const FunctionData *bind_data_p,
   auto &bind_data = (SqliteBindData &)*bind_data_p;
   auto stats = BaseStatistics::CreateEmpty(bind_data.types[column_index]);
   stats->validity_stats =
-      make_unique<ValidityStatistics>(!bind_data.not_nulls[column_index]);
+      make_uniq<ValidityStatistics>(!bind_data.not_nulls[column_index]);
   return stats;
 }
 */
@@ -273,7 +273,7 @@ struct AttachFunctionData : public TableFunctionData {
 static unique_ptr<FunctionData> AttachBind(ClientContext &context, TableFunctionBindInput &input,
                                            vector<LogicalType> &return_types, vector<string> &names) {
 
-	auto result = make_unique<AttachFunctionData>();
+	auto result = make_uniq<AttachFunctionData>();
 	result->file_name = input.inputs[0].GetValue<string>();
 
 	for (auto &kv : input.named_parameters) {

--- a/src/sqlite_storage.cpp
+++ b/src/sqlite_storage.cpp
@@ -14,13 +14,13 @@ namespace duckdb {
 
 static unique_ptr<Catalog> SQLiteAttach(StorageExtensionInfo *storage_info, AttachedDatabase &db, const string &name,
                                         AttachInfo &info, AccessMode access_mode) {
-	return make_unique<SQLiteCatalog>(db, info.path, access_mode);
+	return make_uniq<SQLiteCatalog>(db, info.path, access_mode);
 }
 
 static unique_ptr<TransactionManager> SQLiteCreateTransactionManager(StorageExtensionInfo *storage_info,
                                                                      AttachedDatabase &db, Catalog &catalog) {
 	auto &sqlite_catalog = (SQLiteCatalog &)catalog;
-	return make_unique<SQLiteTransactionManager>(db, sqlite_catalog);
+	return make_uniq<SQLiteTransactionManager>(db, sqlite_catalog);
 }
 
 SQLiteStorageExtension::SQLiteStorageExtension() {

--- a/src/storage/sqlite_catalog.cpp
+++ b/src/storage/sqlite_catalog.cpp
@@ -17,7 +17,7 @@ SQLiteCatalog::~SQLiteCatalog() {
 }
 
 void SQLiteCatalog::Initialize(bool load_builtin) {
-	main_schema = make_unique<SQLiteSchemaEntry>(this);
+	main_schema = make_uniq<SQLiteSchemaEntry>(this);
 }
 
 CatalogEntry *SQLiteCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo *info) {

--- a/src/storage/sqlite_delete.cpp
+++ b/src/storage/sqlite_delete.cpp
@@ -36,7 +36,7 @@ unique_ptr<GlobalSinkState> SQLiteDelete::GetGlobalSinkState(ClientContext &cont
 	auto &sqlite_table = (SQLiteTableEntry &)table;
 
 	auto &transaction = SQLiteTransaction::Get(context, *sqlite_table.catalog);
-	auto result = make_unique<SQLiteDeleteGlobalState>(sqlite_table);
+	auto result = make_uniq<SQLiteDeleteGlobalState>(sqlite_table);
 	result->statement = transaction.GetDB().Prepare(GetDeleteSQL(sqlite_table.name));
 	return std::move(result);
 }
@@ -69,7 +69,7 @@ public:
 };
 
 unique_ptr<GlobalSourceState> SQLiteDelete::GetGlobalSourceState(ClientContext &context) const {
-	return make_unique<SQLiteDeleteSourceState>();
+	return make_uniq<SQLiteDeleteSourceState>();
 }
 
 void SQLiteDelete::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
@@ -103,7 +103,7 @@ unique_ptr<PhysicalOperator> SQLiteCatalog::PlanDelete(ClientContext &context, L
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for deletion of a SQLite table");
 	}
-	auto insert = make_unique<SQLiteDelete>(op, *op.table);
+	auto insert = make_uniq<SQLiteDelete>(op, *op.table);
 	insert->children.push_back(std::move(plan));
 	return std::move(insert);
 }

--- a/src/storage/sqlite_index.cpp
+++ b/src/storage/sqlite_index.cpp
@@ -22,7 +22,7 @@ public:
 };
 
 unique_ptr<GlobalSourceState> SQLiteCreateIndex::GetGlobalSourceState(ClientContext &context) const {
-	return make_unique<SQLiteIndexSourceState>();
+	return make_uniq<SQLiteIndexSourceState>();
 }
 
 void SQLiteCreateIndex::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
@@ -50,7 +50,7 @@ public:
 	TableCatalogEntry &table;
 
 	unique_ptr<PhysicalOperator> CreatePlan(ClientContext &context, PhysicalPlanGenerator &generator) override {
-		return make_unique<SQLiteCreateIndex>(std::move(info), table);
+		return make_uniq<SQLiteCreateIndex>(std::move(info), table);
 	}
 
 	void Serialize(FieldWriter &writer) const override {
@@ -64,8 +64,8 @@ public:
 
 unique_ptr<LogicalOperator> SQLiteCatalog::BindCreateIndex(Binder &binder, CreateStatement &stmt,
                                                            TableCatalogEntry &table, unique_ptr<LogicalOperator> plan) {
-	return make_unique<LogicalSQLiteCreateIndex>(unique_ptr_cast<CreateInfo, CreateIndexInfo>(std::move(stmt.info)),
-	                                             table);
+	return make_uniq<LogicalSQLiteCreateIndex>(unique_ptr_cast<CreateInfo, CreateIndexInfo>(std::move(stmt.info)),
+	                                           table);
 }
 
 } // namespace duckdb

--- a/src/storage/sqlite_insert.cpp
+++ b/src/storage/sqlite_insert.cpp
@@ -87,7 +87,7 @@ unique_ptr<GlobalSinkState> SQLiteInsert::GetGlobalSinkState(ClientContext &cont
 		insert_table = (SQLiteTableEntry *)table;
 	}
 	auto &transaction = SQLiteTransaction::Get(context, *insert_table->catalog);
-	auto result = make_unique<SQLiteInsertGlobalState>(context, insert_table);
+	auto result = make_uniq<SQLiteInsertGlobalState>(context, insert_table);
 	result->statement = transaction.GetDB().Prepare(GetInsertSQL(*this, insert_table));
 	return std::move(result);
 }
@@ -122,7 +122,7 @@ public:
 };
 
 unique_ptr<GlobalSourceState> SQLiteInsert::GetGlobalSourceState(ClientContext &context) const {
-	return make_unique<SQLiteInsertSourceState>();
+	return make_uniq<SQLiteInsertSourceState>();
 }
 
 void SQLiteInsert::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
@@ -168,7 +168,7 @@ unique_ptr<PhysicalOperator> AddCastToSQLiteTypes(ClientContext &context, unique
 		for (idx_t i = 0; i < child_types.size(); i++) {
 			auto &type = child_types[i];
 			unique_ptr<Expression> expr;
-			expr = make_unique<BoundReferenceExpression>(type, i);
+			expr = make_uniq<BoundReferenceExpression>(type, i);
 
 			auto sqlite_type = SQLiteUtils::ToSQLiteType(type);
 			if (sqlite_type != type) {
@@ -179,8 +179,8 @@ unique_ptr<PhysicalOperator> AddCastToSQLiteTypes(ClientContext &context, unique
 			select_list.push_back(std::move(expr));
 		}
 		// we need to cast: add casts
-		auto proj = make_unique<PhysicalProjection>(std::move(sqlite_types), std::move(select_list),
-		                                            plan->estimated_cardinality);
+		auto proj =
+		    make_uniq<PhysicalProjection>(std::move(sqlite_types), std::move(select_list), plan->estimated_cardinality);
 		proj->children.push_back(std::move(plan));
 		plan = std::move(proj);
 	}
@@ -196,7 +196,7 @@ unique_ptr<PhysicalOperator> SQLiteCatalog::PlanInsert(ClientContext &context, L
 
 	plan = AddCastToSQLiteTypes(context, std::move(plan));
 
-	auto insert = make_unique<SQLiteInsert>(op, op.table, op.column_index_map);
+	auto insert = make_uniq<SQLiteInsert>(op, op.table, op.column_index_map);
 	insert->children.push_back(std::move(plan));
 	return std::move(insert);
 }
@@ -205,7 +205,7 @@ unique_ptr<PhysicalOperator> SQLiteCatalog::PlanCreateTableAs(ClientContext &con
                                                               unique_ptr<PhysicalOperator> plan) {
 	plan = AddCastToSQLiteTypes(context, std::move(plan));
 
-	auto insert = make_unique<SQLiteInsert>(op, op.schema, std::move(op.info));
+	auto insert = make_uniq<SQLiteInsert>(op, op.schema, std::move(op.info));
 	insert->children.push_back(std::move(plan));
 	return std::move(insert);
 }

--- a/src/storage/sqlite_table_entry.cpp
+++ b/src/storage/sqlite_table_entry.cpp
@@ -16,7 +16,7 @@ unique_ptr<BaseStatistics> SQLiteTableEntry::GetStatistics(ClientContext &contex
 }
 
 TableFunction SQLiteTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
-	auto result = make_unique<SqliteBindData>();
+	auto result = make_uniq<SqliteBindData>();
 	for (auto &col : columns.Logical()) {
 		result->names.push_back(col.GetName());
 		result->types.push_back(col.GetType());

--- a/src/storage/sqlite_transaction.cpp
+++ b/src/storage/sqlite_transaction.cpp
@@ -64,7 +64,7 @@ CatalogEntry *SQLiteTransaction::GetCatalogEntry(const string &entry_name) {
 		db->GetTableInfo(entry_name, info.columns, info.constraints, false);
 		D_ASSERT(!info.columns.empty());
 
-		result = make_unique<SQLiteTableEntry>(&sqlite_catalog, sqlite_catalog.GetMainSchema(), info);
+		result = make_uniq<SQLiteTableEntry>(&sqlite_catalog, sqlite_catalog.GetMainSchema(), info);
 		break;
 	}
 	case CatalogType::VIEW_ENTRY: {
@@ -73,7 +73,7 @@ CatalogEntry *SQLiteTransaction::GetCatalogEntry(const string &entry_name) {
 
 		auto view_info = CreateViewInfo::FromCreateView(*context.lock(), sql);
 		view_info->internal = false;
-		result = make_unique<ViewCatalogEntry>(&sqlite_catalog, sqlite_catalog.GetMainSchema(), view_info.get());
+		result = make_uniq<ViewCatalogEntry>(&sqlite_catalog, sqlite_catalog.GetMainSchema(), view_info.get());
 		break;
 	}
 	case CatalogType::INDEX_ENTRY: {
@@ -84,8 +84,8 @@ CatalogEntry *SQLiteTransaction::GetCatalogEntry(const string &entry_name) {
 		string sql;
 		db->GetIndexInfo(entry_name, sql, table_name);
 
-		auto index_entry = make_unique<SQLiteIndexEntry>(&sqlite_catalog, sqlite_catalog.GetMainSchema(), &info,
-		                                                 std::move(table_name));
+		auto index_entry =
+		    make_uniq<SQLiteIndexEntry>(&sqlite_catalog, sqlite_catalog.GetMainSchema(), &info, std::move(table_name));
 		index_entry->sql = std::move(sql);
 		result = std::move(index_entry);
 		break;

--- a/src/storage/sqlite_transaction_manager.cpp
+++ b/src/storage/sqlite_transaction_manager.cpp
@@ -8,7 +8,7 @@ SQLiteTransactionManager::SQLiteTransactionManager(AttachedDatabase &db_p, SQLit
 }
 
 Transaction *SQLiteTransactionManager::StartTransaction(ClientContext &context) {
-	auto transaction = make_unique<SQLiteTransaction>(sqlite_catalog, *this, context);
+	auto transaction = make_uniq<SQLiteTransaction>(sqlite_catalog, *this, context);
 	transaction->Start();
 	auto result = transaction.get();
 	lock_guard<mutex> l(transaction_lock);

--- a/src/storage/sqlite_update.cpp
+++ b/src/storage/sqlite_update.cpp
@@ -45,7 +45,7 @@ unique_ptr<GlobalSinkState> SQLiteUpdate::GetGlobalSinkState(ClientContext &cont
 	auto &sqlite_table = (SQLiteTableEntry &)table;
 
 	auto &transaction = SQLiteTransaction::Get(context, *sqlite_table.catalog);
-	auto result = make_unique<SQLiteUpdateGlobalState>(sqlite_table);
+	auto result = make_uniq<SQLiteUpdateGlobalState>(sqlite_table);
 	result->statement = transaction.GetDB().Prepare(GetUpdateSQL(sqlite_table, columns));
 	return std::move(result);
 }
@@ -86,7 +86,7 @@ public:
 };
 
 unique_ptr<GlobalSourceState> SQLiteUpdate::GetGlobalSourceState(ClientContext &context) const {
-	return make_unique<SQLiteUpdateSourceState>();
+	return make_uniq<SQLiteUpdateSourceState>();
 }
 
 void SQLiteUpdate::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
@@ -125,7 +125,7 @@ unique_ptr<PhysicalOperator> SQLiteCatalog::PlanUpdate(ClientContext &context, L
 			throw BinderException("SET DEFAULT is not yet supported for updates of a SQLite table");
 		}
 	}
-	auto insert = make_unique<SQLiteUpdate>(op, *op.table, std::move(op.columns));
+	auto insert = make_uniq<SQLiteUpdate>(op, *op.table, std::move(op.columns));
 	insert->children.push_back(std::move(plan));
 	return std::move(insert);
 }


### PR DESCRIPTION
This PR is made in preparation of migrating DuckDB to use it's own `unique_ptr` implementation
Removing the use of `std::make_unique` and changing it to `duckdb::make_uniq`
`make_unique` -> `make_uniq` is done to avoid clashing with the std namespace and having to explicitly qualify every call.