### PR TITLE
Correctly fill IndexInfo in GetStorageInfo

### DIFF
--- a/src/include/sqlite_db.hpp
+++ b/src/include/sqlite_db.hpp
@@ -12,6 +12,7 @@
 
 namespace duckdb {
 class SQLiteStatement;
+struct IndexInfo;
 
 class SQLiteDB {
 public:
@@ -44,6 +45,7 @@ public:
 	//! Gets the max row id of a table, returns false if the table does not have a rowid column
 	bool GetMaxRowId(const string &table_name, idx_t &row_id);
 	bool ColumnExists(const string &table_name, const string &column_name);
+	vector<IndexInfo> GetIndexInfo(const string &table_name);
 
 	bool IsOpen();
 	void Close();

--- a/src/storage/sqlite_insert.cpp
+++ b/src/storage/sqlite_insert.cpp
@@ -181,6 +181,9 @@ unique_ptr<PhysicalOperator> SQLiteCatalog::PlanInsert(ClientContext &context, L
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for insertion into SQLite table");
 	}
+	if (op.action_type != OnConflictAction::THROW) {
+		throw BinderException("ON CONFLICT clause not yet supported for insertion into SQLite table");
+	}
 
 	plan = AddCastToSQLiteTypes(context, std::move(plan));
 

--- a/src/storage/sqlite_table_entry.cpp
+++ b/src/storage/sqlite_table_entry.cpp
@@ -51,6 +51,7 @@ TableStorageInfo SQLiteTableEntry::GetStorageInfo(ClientContext &context) {
 		// probably
 		result.cardinality = 10000;
 	}
+	result.index_info = db.GetIndexInfo(name);
 	return result;
 }
 

--- a/test/lite_storage/attach_on_conflict.test
+++ b/test/lite_storage/attach_on_conflict.test
@@ -18,4 +18,13 @@ UNIQUE constraint failed
 statement error
 INSERT OR IGNORE INTO s.tbl VALUES (1)
 ----
-ON CONFLICT clause is not yet supported
+ON CONFLICT clause not yet supported for insertion into SQLite table
+
+# INSERT OR IGNORE in a table without primary key constraints
+statement ok
+CREATE TABLE s.tbl2(i INTEGER)
+
+statement error
+INSERT OR REPLACE INTO s.tbl2 VALUES (1)
+----
+There are no UNIQUE/PRIMARY KEY Indexes


### PR DESCRIPTION
This allows the index info to be used during binding - which allows us to bind `ON CONFLICT` clauses and statements like `INSERT OR IGNORE`. Note that we don't yet implement `ON CONFLICT` in the `SQLiteInsert` method - but this brings us further along towards implementing that.